### PR TITLE
Fix bin

### DIFF
--- a/gistfy.js
+++ b/gistfy.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var PORT = process.env.OPENSHIFT_NODEJS_PORT || 3000,
     IP_ADDRESS = process.env.OPENSHIFT_NODEJS_IP || '127.0.0.1';
 


### PR DESCRIPTION
You need a hashbang to allow the script to be run globally otherwise you get somthing like this.

```
Failed to execute process '/usr/bin/gistfy'. Reason:
exec: Exec format error
The file '/usr/bin/gistfy' is marked as an executable but could not be run by the operating system.
```
