### PR TITLE
Make config.base_url a string so you can set it without erroring

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,15 +1,8 @@
 var rc = require('rc');
 
-module.exports = rc('gistfy', {
+var config = {
     host: process.env.OPENSHIFT_NODEJS_IP || '127.0.0.1',
     port: process.env.OPENSHIFT_NODEJS_PORT || 3000,
-    base_url: function() {
-        if (process.env.OPENSHIFT_APP_DNS) {
-            return 'http://' + process.env.OPENSHIFT_APP_DNS;
-        } else {
-            return 'http://' + this.host + ':' + this.port;
-        }
-    },
 
     user_agent: function() {
         return 'Gistfy-App ' + require('../package.json').version;
@@ -19,5 +12,13 @@ module.exports = rc('gistfy', {
     theme: 'github',
     locale: 'en',
     branch: 'master'
-});
+};
+config.base_url = (function() {
+    if (process.env.OPENSHIFT_APP_DNS) {
+        return 'http://' + process.env.OPENSHIFT_APP_DNS;
+    } else {
+        return 'http://' + this.host + ':' + this.port;
+    }
+}).call(config);
+module.exports = rc('gistfy', config);
 

--- a/src/gistfy.js
+++ b/src/gistfy.js
@@ -162,12 +162,12 @@ function processData(data, slice) {
 function buildResponse(type, options, callback) {
     switch (type) {
         case "js":
-            var js = 'document.write(\'<link rel=\"stylesheet\" href=\"' + config.base_url() + '/css/gistfy.github.css\">\');\n'+
+            var js = 'document.write(\'<link rel=\"stylesheet\" href=\"' + config.base_url + '/css/gistfy.github.css\">\');\n'+
                      'document.write(\'' + escapeJS(template(options)) + '\');';
             callback(200, js, 'text/javascript');
             break;
         case "html":
-            var html = '<link rel=\"stylesheet\" href=\"' + config.base_url() + '/css/gistfy.github.css\">' + template(options);
+            var html = '<link rel=\"stylesheet\" href=\"' + config.base_url + '/css/gistfy.github.css\">' + template(options);
             callback(200, html, 'text/html');
             break;
         default:


### PR DESCRIPTION
If you try to set `base_url`(`--base_url="your.url"`) to a string you would get an error because it was looking for a function.
